### PR TITLE
Update webpack.rake to add production mode flag

### DIFF
--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -13,7 +13,7 @@ namespace :webpack do
       raise "Can't find our webpack config file at #{config_file}"
     end
 
-    result =  `#{webpack_bin} --bail --config #{config_file} 2>&1`
+    result =  `#{webpack_bin} --bail --config #{config_file} 2>&1 --mode production`
     raise result unless $? == 0
   end
 end


### PR DESCRIPTION
Update webpack.rake to add production mode flag for compilation.

It's added by default for webpack 4, but it removed unnecessary warnings.